### PR TITLE
Minimize container resources to allow for feature preview

### DIFF
--- a/k8s/gcp/core/deployment.yml
+++ b/k8s/gcp/core/deployment.yml
@@ -65,9 +65,12 @@ spec:
             - containerPort: 5000
               protocol: TCP
           resources:
+            requests:
+              memory: "250Mi"
+              cpu: "250m"
             limits:
-              memory: "1Gi"
-              cpu: "100m"
+              memory: "250Mi"
+              cpu: "250m"
           livenessProbe:
             httpGet:
               path: /test
@@ -91,6 +94,9 @@ spec:
             runAsUser: 65532
             runAsGroup: 65532
           resources:
+            requests:
+              memory: "250Mi"
+              cpu: "25m"
             limits:
-              memory: "250M"
+              memory: "250Mi"
               cpu: "25m"

--- a/k8s/gcp/ui/deployment.yml
+++ b/k8s/gcp/ui/deployment.yml
@@ -60,8 +60,8 @@ spec:
             protocol: TCP
         resources:
           requests:
-            memory: "1G"
-            cpu: "1"
+            memory: "250M"
+            cpu: "250m"
           limits:
-            memory: "1G"
-            cpu: "1"
+            memory: "250M"
+            cpu: "250m"


### PR DESCRIPTION
This is a precursor to enabling the feature preview functionality. We need container resources to be at a minimum so the current cluster can allow up to 3 features to be deployed (up to 3 active PR) concurrently.